### PR TITLE
Fix image rendering stutters from long-running method calls in ImageManager.saveBufferedImageAsIdentifier()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
@@ -55,8 +55,8 @@ java {
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
 
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
@@ -8,15 +8,16 @@ import org.joml.Vector2i;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Objects;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ImageData {
     private BufferedImage baseImage;
     private Identifier baseIdentifier;
     private Identifier workingIdentifier;
-    private final HashMap<Vector2i, VariantData> images;
+    private final ConcurrentHashMap<Vector2i, VariantData> images = new ConcurrentHashMap<>();
+    private final Set<Identifier> loadingImages = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
     public boolean ready = false;
     public boolean needsReload = false;
 
@@ -29,8 +30,8 @@ public class ImageData {
 
     private int expiredAllAt = -1;
 
+
     public ImageData() {
-        this.images = new HashMap<>();
     }
 
     public void onImageReady(BufferedImage image, Identifier baseIdentifier) {
@@ -61,8 +62,9 @@ public class ImageData {
             if (width != workingWidth || height != workingHeight) {
                 workingWidth = width;
                 workingHeight = height;
-                ImageManager.saveBufferedImageAsIdentifier(scaleImage(baseImage, width, height), workingIdentifier);
+                ImageManager.saveBufferedImageAsIdentifier(scaleImage(baseImage, width, height), workingIdentifier).join();
             }
+
             return workingIdentifier;
         } else {
             Identifier identifier;
@@ -76,8 +78,23 @@ public class ImageData {
                 bufferedImage = scaleImage(baseImage, width, height);
             }
 
-            ImageManager.saveBufferedImageAsIdentifier(bufferedImage, identifier);
-            images.put(resolution, new VariantData(identifier));
+            if (loadingImages.contains(identifier))
+                return identifier;
+
+            loadingImages.add(identifier);
+
+            ImageManager.saveBufferedImageAsIdentifier(bufferedImage, identifier).handleAsync((v, e) -> {
+                if (e != null)
+                {
+                    loadingImages.remove(identifier);
+                    return null;
+                }
+                images.put(resolution, new VariantData(identifier));
+                loadingImages.remove(identifier);
+
+                return null;
+            });
+
             return identifier;
         }
     }

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
@@ -78,6 +78,9 @@ public class ImageData {
                 bufferedImage = scaleImage(baseImage, width, height);
             }
 
+            if (identifier == null)
+                return null;
+
             if (loadingImages.contains(identifier))
                 return identifier;
 

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageData.java
@@ -62,7 +62,7 @@ public class ImageData {
             if (width != workingWidth || height != workingHeight) {
                 workingWidth = width;
                 workingHeight = height;
-                ImageManager.saveBufferedImageAsIdentifier(scaleImage(baseImage, width, height), workingIdentifier).join();
+                ImageManager.saveBufferedImageAsIdentifier(scaleImage(baseImage, width, height), workingIdentifier);
             }
 
             return workingIdentifier;
@@ -83,7 +83,7 @@ public class ImageData {
 
             loadingImages.add(identifier);
 
-            ImageManager.saveBufferedImageAsIdentifier(bufferedImage, identifier).handleAsync((v, e) -> {
+            ImageManager.saveBufferedImageAsIdentifierAsync(bufferedImage, identifier).handleAsync((v, e) -> {
                 if (e != null)
                 {
                     loadingImages.remove(identifier);

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
@@ -333,9 +333,8 @@ public class ImageManager {
         return builder.toString();
     }
 
-    public static CompletableFuture<Void> saveBufferedImageAsIdentifier(BufferedImage bufferedImage, Identifier identifier) {
-        // https://discord.com/channels/507304429255393322/807617488313516032/934395931380576287
-        return CompletableFuture.supplyAsync(() -> {
+    public static void saveBufferedImageAsIdentifier(BufferedImage bufferedImage, Identifier identifier) {
+        {
             if (SignedPaintingsClient.imageManager != null) {
                 SignedPaintingsClient.imageManager.checkAndCacheTranslucency(identifier, bufferedImage);
             } else {
@@ -351,8 +350,7 @@ public class ImageManager {
                 if (SignedPaintingsClient.imageManager != null) {
                     SignedPaintingsClient.imageManager.translucencyCache.put(identifier, false);
                 }
-
-                return null;
+                return;
             }
 
             byte[] bytes = stream.toByteArray();
@@ -381,7 +379,6 @@ public class ImageManager {
                             nativeImage.get().getHeight() * nativeImage.get().getWidth() * nativeImage.get().getFormat().getChannelCount());
 
                     MemoryUtil.memCopy(byteBuffer, nativeImageBuffer);
-
                     MinecraftClient.getInstance().submitAndJoin(() -> {
                         NativeImageBackedTexture texture = new NativeImageBackedTexture(identifier::toString, nativeImage.get());
                         MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, texture);
@@ -390,6 +387,13 @@ public class ImageManager {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
+        }
+    }
+
+    public static CompletableFuture<Void> saveBufferedImageAsIdentifierAsync(BufferedImage bufferedImage, Identifier identifier) {
+        // https://discord.com/channels/507304429255393322/807617488313516032/934395931380576287
+        return CompletableFuture.supplyAsync(() -> {
+            saveBufferedImageAsIdentifier(bufferedImage, identifier);
             return null;
         }, threadPoolExecutor);
     }

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
@@ -334,59 +334,57 @@ public class ImageManager {
     }
 
     public static void saveBufferedImageAsIdentifier(BufferedImage bufferedImage, Identifier identifier) {
-        {
+        if (SignedPaintingsClient.imageManager != null) {
+            SignedPaintingsClient.imageManager.checkAndCacheTranslucency(identifier, bufferedImage);
+        } else {
+            SignedPaintingsClient.info("ImageManager instance not available for transparency check: " + identifier, true);
+        }
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        try {
+            ImageIO.write(bufferedImage, "png", stream);
+        } catch (IOException e) {
+            SignedPaintingsClient.info("Failed to convert/register BufferedImage for identifier \"" + identifier + "\": " + e.getMessage(), true);
             if (SignedPaintingsClient.imageManager != null) {
-                SignedPaintingsClient.imageManager.checkAndCacheTranslucency(identifier, bufferedImage);
-            } else {
-                SignedPaintingsClient.info("ImageManager instance not available for transparency check: " + identifier, true);
+                SignedPaintingsClient.imageManager.translucencyCache.put(identifier, false);
             }
+            return;
+        }
 
-            ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        byte[] bytes = stream.toByteArray();
 
-            try {
-                ImageIO.write(bufferedImage, "png", stream);
-            } catch (IOException e) {
-                SignedPaintingsClient.info("Failed to convert/register BufferedImage for identifier \"" + identifier + "\": " + e.getMessage(), true);
-                if (SignedPaintingsClient.imageManager != null) {
-                    SignedPaintingsClient.imageManager.translucencyCache.put(identifier, false);
+        ByteBuffer data = BufferUtils.createByteBuffer(bytes.length).put(bytes);
+        data.flip();
+
+        try {
+            PngMetadata.validate(data);
+
+            try (MemoryStack memoryStack = MemoryStack.stackPush()) {
+                IntBuffer xBuffer = memoryStack.mallocInt(1);
+                IntBuffer yBuffer = memoryStack.mallocInt(1);
+                IntBuffer channelBuffer = memoryStack.mallocInt(1);
+                ByteBuffer byteBuffer = STBImage.stbi_load_from_memory(data, xBuffer, yBuffer, channelBuffer, 4);
+
+                AtomicReference<NativeImage> nativeImage = new AtomicReference<>();
+                MinecraftClient.getInstance().submitAndJoin(() ->
+                        nativeImage.set(new NativeImage(NativeImage.Format.RGBA, xBuffer.get(0), yBuffer.get(0), true)));
+
+                if (byteBuffer == null) {
+                    throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
                 }
-                return;
+
+                var nativeImageBuffer = MemoryUtil.memByteBuffer(nativeImage.get().imageId(),
+                        nativeImage.get().getHeight() * nativeImage.get().getWidth() * nativeImage.get().getFormat().getChannelCount());
+
+                MemoryUtil.memCopy(byteBuffer, nativeImageBuffer);
+                MinecraftClient.getInstance().submitAndJoin(() -> {
+                    NativeImageBackedTexture texture = new NativeImageBackedTexture(identifier::toString, nativeImage.get());
+                    MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, texture);
+                });
             }
-
-            byte[] bytes = stream.toByteArray();
-
-            ByteBuffer data = BufferUtils.createByteBuffer(bytes.length).put(bytes);
-            data.flip();
-
-            try {
-                PngMetadata.validate(data);
-
-                try (MemoryStack memoryStack = MemoryStack.stackPush()) {
-                    IntBuffer xBuffer = memoryStack.mallocInt(1);
-                    IntBuffer yBuffer = memoryStack.mallocInt(1);
-                    IntBuffer channelBuffer = memoryStack.mallocInt(1);
-                    ByteBuffer byteBuffer = STBImage.stbi_load_from_memory(data, xBuffer, yBuffer, channelBuffer, 4);
-
-                    AtomicReference<NativeImage> nativeImage = new AtomicReference<>();
-                    MinecraftClient.getInstance().submitAndJoin(() ->
-                            nativeImage.set(new NativeImage(NativeImage.Format.RGBA, xBuffer.get(0), yBuffer.get(0), true)));
-
-                    if (byteBuffer == null) {
-                        throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
-                    }
-
-                    var nativeImageBuffer = MemoryUtil.memByteBuffer(nativeImage.get().imageId(),
-                            nativeImage.get().getHeight() * nativeImage.get().getWidth() * nativeImage.get().getFormat().getChannelCount());
-
-                    MemoryUtil.memCopy(byteBuffer, nativeImageBuffer);
-                    MinecraftClient.getInstance().submitAndJoin(() -> {
-                        NativeImageBackedTexture texture = new NativeImageBackedTexture(identifier::toString, nativeImage.get());
-                        MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, texture);
-                    });
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
@@ -16,11 +16,16 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 
 import java.net.URI;
+import java.nio.IntBuffer;
 import java.util.Map;
 import java.util.HashMap;
 
+import net.minecraft.util.PngMetadata;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.BufferUtils;
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -29,7 +34,10 @@ import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class ImageManager {
     private final String dataHeader = "https://modrinth.com/mod/signed-paintings config v";
@@ -46,6 +54,9 @@ public class ImageManager {
     public final Set<String> blockPromptedDomains;
     public boolean autoBlockNew = false;
     public int renderTime = 0;
+
+    private static final Executor virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
+    private static final Executor threadPoolExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
     private boolean changesMade = false;
     public boolean hasTranslucency(Identifier id) {
@@ -75,11 +86,11 @@ public class ImageManager {
 
                     if (alpha > 0 && alpha < 255) {
                         hasTranslucency = true;
-                        break; 
+                        break;
                     }
                 }
                 if (hasTranslucency) {
-                    break; 
+                    break;
                 }
             }
         } catch (Exception e) {
@@ -322,40 +333,66 @@ public class ImageManager {
         return builder.toString();
     }
 
-    public static void saveBufferedImageAsIdentifier(BufferedImage bufferedImage, Identifier identifier) {
+    public static CompletableFuture<Void> saveBufferedImageAsIdentifier(BufferedImage bufferedImage, Identifier identifier) {
         // https://discord.com/channels/507304429255393322/807617488313516032/934395931380576287
-        try {
+        return CompletableFuture.supplyAsync(() -> {
             if (SignedPaintingsClient.imageManager != null) {
-                 SignedPaintingsClient.imageManager.checkAndCacheTranslucency(identifier, bufferedImage);
+                SignedPaintingsClient.imageManager.checkAndCacheTranslucency(identifier, bufferedImage);
             } else {
-                 SignedPaintingsClient.info("ImageManager instance not available for transparency check: " + identifier, true);
+                SignedPaintingsClient.info("ImageManager instance not available for transparency check: " + identifier, true);
             }
 
             ByteArrayOutputStream stream = new ByteArrayOutputStream();
-            ImageIO.write(bufferedImage, "png", stream);
+
+            try {
+                ImageIO.write(bufferedImage, "png", stream);
+            } catch (IOException e) {
+                SignedPaintingsClient.info("Failed to convert/register BufferedImage for identifier \"" + identifier + "\": " + e.getMessage(), true);
+                if (SignedPaintingsClient.imageManager != null) {
+                    SignedPaintingsClient.imageManager.translucencyCache.put(identifier, false);
+                }
+
+                return null;
+            }
+
             byte[] bytes = stream.toByteArray();
 
             ByteBuffer data = BufferUtils.createByteBuffer(bytes.length).put(bytes);
             data.flip();
 
-            MinecraftClient.getInstance().execute(() -> {
-                try {
-                    NativeImage img = NativeImage.read(data);
-                    NativeImageBackedTexture texture = new NativeImageBackedTexture(identifier::toString, img);
-                    MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, texture);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
+            try {
+                PngMetadata.validate(data);
+
+                try (MemoryStack memoryStack = MemoryStack.stackPush()) {
+                    IntBuffer xBuffer = memoryStack.mallocInt(1);
+                    IntBuffer yBuffer = memoryStack.mallocInt(1);
+                    IntBuffer channelBuffer = memoryStack.mallocInt(1);
+                    ByteBuffer byteBuffer = STBImage.stbi_load_from_memory(data, xBuffer, yBuffer, channelBuffer, 4);
+
+                    AtomicReference<NativeImage> nativeImage = new AtomicReference<>();
+                    MinecraftClient.getInstance().submitAndJoin(() ->
+                            nativeImage.set(new NativeImage(NativeImage.Format.RGBA, xBuffer.get(0), yBuffer.get(0), true)));
+
+                    if (byteBuffer == null) {
+                        throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
+                    }
+
+                    var nativeImageBuffer = MemoryUtil.memByteBuffer(nativeImage.get().imageId(),
+                            nativeImage.get().getHeight() * nativeImage.get().getWidth() * nativeImage.get().getFormat().getChannelCount());
+
+                    MemoryUtil.memCopy(byteBuffer, nativeImageBuffer);
+
+                    MinecraftClient.getInstance().submitAndJoin(() -> {
+                        NativeImageBackedTexture texture = new NativeImageBackedTexture(identifier::toString, nativeImage.get());
+                        MinecraftClient.getInstance().getTextureManager().registerTexture(identifier, texture);
+                    });
                 }
-            });
-
-        } catch (Throwable e) {
-            SignedPaintingsClient.info("Failed to convert/register BufferedImage for identifier \"" + identifier + "\": " + e.getMessage(), true);
-            if (SignedPaintingsClient.imageManager != null) {
-                 SignedPaintingsClient.imageManager.translucencyCache.put(identifier, false);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
-        }
+            return null;
+        }, threadPoolExecutor);
     }
-
 
     public static void removeImage(Identifier identifier) {
         MinecraftClient.getInstance().execute(() -> MinecraftClient.getInstance().getTextureManager().destroyTexture(identifier));
@@ -389,7 +426,7 @@ public class ImageManager {
                 SignedPaintingsClient.info("error downloading image "+urlStr+" : "+e, true);
                 return null;
             }
-        });
+        }, virtualThreadExecutor);
     }
 
     public static boolean isValid(@NotNull String url) {


### PR DESCRIPTION
In certain areas with lots of signed paintings, SignedPaintings will create some stuttering while it loads the images. Here's some profiling results on what exactly causes the lag:

<img width="1678" height="787" alt="image" src="https://github.com/user-attachments/assets/9de38363-d2ee-4ded-b7a8-a0ee49a63bf4" />

ImageManager.saveBufferedImageAsIdentifier() seems to be the culprit. In particular, ImageIO.write() takes a very long time for certain images. After moving that to a background thread, there was still some stuttering. The culprit this time was a call to STBImage.stbi_load_from_memory() in NativeImage.read():

<img width="1872" height="622" alt="image" src="https://github.com/user-attachments/assets/85ad1f45-f97e-40aa-b315-86c9633421e8" />

NativeImage.read() is probably not thread-safe (I tried moving it to its own thread and images failed to render), so I re-implemented it in ImageManager.saveBufferedImageAsIdentifier(), making sure that NativeImage allocates memory and is registered to textures only on the main thread.

After moving the aforementioned operations to a background thread and repeating the profiling in the same signed-paintings-filled area, the stutters caused by ImageManager.saveBufferedImageAsIdentifier() went away.