### PR TITLE
Fix occasional crashing on some platforms by using SingleThreadExecutor

### DIFF
--- a/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
+++ b/src/main/java/com/nettakrim/signed_paintings/util/ImageManager.java
@@ -56,7 +56,7 @@ public class ImageManager {
     public int renderTime = 0;
 
     private static final Executor virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
-    private static final Executor threadPoolExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    private static final Executor singleThreadExecutor = Executors.newSingleThreadExecutor();
 
     private boolean changesMade = false;
     public boolean hasTranslucency(Identifier id) {
@@ -393,7 +393,7 @@ public class ImageManager {
         return CompletableFuture.supplyAsync(() -> {
             saveBufferedImageAsIdentifier(bufferedImage, identifier);
             return null;
-        }, threadPoolExecutor);
+        }, singleThreadExecutor);
     }
 
     public static void removeImage(Identifier identifier) {


### PR DESCRIPTION
https://github.com/Nettakrim/Signed-Paintings/pull/63 introduced occasional crashing on some platforms. I did not experience any crashing as a Linux user. A user report yields the following error log:

```
---------------  T H R E A D  ---------------

Current thread (0x000002321bec1ca0):  JavaThread "pool-11-thread-7"        [_thread_in_native, id=19684, stack(0x000000463da00000,0x000000463db00000) (1024K)]

Stack: [0x000000463da00000,0x000000463db00000],  sp=0x000000463dafd980,  free space=1014k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [lwjgl_stb.dll+0x56fd]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 17682  org.lwjgl.stb.STBImage.nstbi_load_from_memory(JIJJJI)J (0 bytes) @ 0x0000023275086e34 [0x0000023275086dc0+0x0000000000000074]
J 238464 c2 org.lwjgl.stb.STBImage.stbi_load_from_memory(Ljava/nio/ByteBuffer;Ljava/nio/IntBuffer;Ljava/nio/IntBuffer;Ljava/nio/IntBuffer;I)Ljava/nio/ByteBuffer; (90 bytes) @ 0x00000232763af8d8 [0x00000232763af800+0x00000000000000d8]
J 238350 c1 com.nettakrim.signed_paintings.util.ImageManager.saveBufferedImageAsIdentifier(Ljava/awt/image/BufferedImage;Lnet/minecraft/class_2960;)V (340 bytes) @ 0x000002326fbf4b34 [0x000002326fbf2780+0x00000000000023b4]
J 238257 c1 com.nettakrim.signed_paintings.util.ImageManager$$Lambda+0x0000000801f12190.get()Ljava/lang/Object; (12 bytes) @ 0x000002326d79c10c [0x000002326d79c040+0x00000000000000cc]
J 17855 c2 java.util.concurrent.CompletableFuture$AsyncSupply.run()V java.base@21.0.7 (61 bytes) @ 0x000002327521930c [0x0000023275219260+0x00000000000000ac]
J 85694 c2 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V java.base@21.0.7 (187 bytes) @ 0x000002327724ec44 [0x000002327724e500+0x0000000000000744]
j  java.util.concurrent.ThreadPoolExecutor$Worker.run()V+5 java.base@21.0.7
J 24374 c1 java.lang.Thread.run()V java.base@21.0.7 (23 bytes) @ 0x000002326f0c7974 [0x000002326f0c7760+0x0000000000000214]
v  ~StubRoutines::call_stub 0x00000232746c10e7

siginfo: EXCEPTION_ACCESS_VIOLATION (0xc0000005), reading address 0x00000232b59a0266
```

```
Platform
Host: AMD Ryzen 7 7700 8-Core Processor              , 16 cores, 31G,  Windows 11 , 64 bit Build 26100 (10.0.26100.7920)

---------------  S Y S T E M  ---------------

OS:
 Windows 11 , 64 bit Build 26100 (10.0.26100.7920)
OS uptime: 0 days 7:42 hours
Hyper-V role detected

CPU: total 16 (initial active 16) (16 cores per cpu, 2 threads per core) family 25 model 97 stepping 2 microcode 0xa60120c, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4a, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, adx, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, sha, fma, vzeroupper, avx512_vpopcntdq, avx512_vpclmulqdq, avx512_vaes, avx512_vnni, clflush, clflushopt, avx512_vbmi2, avx512_vbmi, hv, rdtscp, rdpid, fsrm, gfni, avx512_bitalg, f16c, cet_ss, avx512_ifma
Processor Information for the first 16 processors :
  Max Mhz: 3801, Current Mhz: 3801, Mhz Limit: 3801

Memory: 4k page, system-wide physical 31861M (13302M free)
TotalPageFile size 41077M (AvailPageFile size 9314M)
current process WorkingSet (physical memory assigned to process): 4519M, peak: 6315M
current process commit charge ("private bytes"): 12014M, peak: 13491M

vm_info: OpenJDK 64-Bit Server VM (21.0.7+6-LTS) for windows-amd64 JRE (21.0.7+6-LTS), built on 2025-04-09T22:17:25Z by "MicrosoftCorporation" with unknown MS VC++:1939

```

The crashing occurs in native code at ``org.lwjgl.stb.STBImage.nstbi_load_from_memory`` and seems to be the result of some kind of thread safety issue with the ``stb_image`` library that Minecraft uses. Reducing the number of threads able to run ``ImageManager.saveBufferedImageAsIdentifier`` at the same time to one seems to fix the crashing, as reported by the user who experienced crashing when using a new build with this fix included.